### PR TITLE
fix: Etime fix in import.LI8100.R

### DIFF
--- a/R/import.LI8100.R
+++ b/R/import.LI8100.R
@@ -93,7 +93,7 @@
 
 import.LI8100 <- function(inputfile, date.format = "ymd", timezone = "UTC",
                           save = FALSE, keep_all = FALSE, prec = c(1, 10)) {
-
+  
   # Check arguments
   if (missing(inputfile)) stop("'inputfile' is required")
   if (!is.character(inputfile)) stop("'inputfile' must be of class character")
@@ -107,22 +107,22 @@ import.LI8100 <- function(inputfile, date.format = "ymd", timezone = "UTC",
   if(is.null(prec)) stop("'prec' is required") else{
     if(!is.numeric(prec)) stop("'prec' must be of class numeric") else{
       if(length(prec) != 2) stop("'prec' must be of length 2")}}
-
+  
   # Assign NULL to variables without binding
   Type <- Etime <- Tcham <- Pressure <- H2O <- . <- Cdry <- V1 <- V2 <- V3 <-
     V4 <- H2O_mmol <- DATE_TIME <- Obs <- cham.close <- cham.open <- plotID <-
     deadband <- start.time <- obs.start <- POSIX.time <- import.error <-
     Date <- CO2dry_ppm <- POSIX.warning <- H2O_ppm <- Pcham <- Obs2 <- NULL
-
+  
   # Input file name
   inputfile.name <- gsub(".*/", "", inputfile)
-
+  
   # Try to load data file
   try.import <- tryCatch(
     {read.delim(inputfile)},
     error = function(e) {import.error <<- e}
   )
-
+  
   # Skip first line in problematic files
   skip.extra <- 0
   if(inherits(try.import, "simpleError")){
@@ -133,21 +133,22 @@ import.LI8100 <- function(inputfile, date.format = "ymd", timezone = "UTC",
       )
       skip.extra <- 1
     }}
-
+  
   if(inherits(try.import, "simpleError")){
     warning("Error occurred in file ", inputfile.name, ":\n", "   ",
             import.error, call. = F)
   } else {
-
+    
     # Find how many rows need to be skipped
     skip.rows <- as.numeric(which(try.import == "Type"))[1] + skip.extra
-
+    
     # Import raw data file from LI8100 (.81x)
     data.raw <- read.delim(inputfile, skip = skip.rows) %>%
       # Keep only Type == 1, as everything else is metadata
       filter(Type == "1") %>%
       # Standardize column names
-      rename(DATE_TIME = Date, Pcham = Pressure, H2O_mmol = H2O, CO2dry_ppm = Cdry) %>%
+      rename(DATE_TIME = Date, Pcham = Pressure, H2O_mmol = H2O,
+             CO2dry_ppm = Cdry) %>%
       # Convert column class automatically
       type.convert(as.is = TRUE) %>%
       # Convert mmol into ppm for H2O
@@ -156,13 +157,13 @@ import.LI8100 <- function(inputfile, date.format = "ymd", timezone = "UTC",
       arrange(DATE_TIME) %>%
       mutate(Obs2 = ifelse(is.na(Etime - lag(Etime)), 0, Etime - lag(Etime))) %>%
       mutate(Obs2 = rleid(cumsum(Obs2 < 0)))
-
+    
     # Keep only useful columns for gas flux calculation
     if(keep_all == FALSE){
       data.raw <- data.raw %>%
         select(Obs2, DATE_TIME, Etime, H2O_ppm, CO2dry_ppm,
                Tcham, Pcham, V1, V2, V3, V4)}
-
+    
     # Create a new column containing date and time (POSIX format)
     tryCatch(
       {if(date.format == "dmy"){
@@ -173,7 +174,7 @@ import.LI8100 <- function(inputfile, date.format = "ymd", timezone = "UTC",
         try.POSIX <- as.POSIXct(ymd_hms(data.raw$DATE_TIME, tz = timezone))
       }}, warning = function(w) {POSIX.warning <<- "date.format.error"}
     )
-
+    
     if(isTRUE(POSIX.warning == "date.format.error")){
       warning("Error occurred in file ", inputfile.name, ":\n",
               "   An error occured while converting DATE and TIME into POSIX.time.\n",
@@ -182,14 +183,14 @@ import.LI8100 <- function(inputfile, date.format = "ymd", timezone = "UTC",
               "   column 'DATE' in the raw data file. Here is a sample: ",
               data.raw$DATE_TIME[1], "\n", call. = F)
     } else {
-
+      
       data.raw$POSIX.time <- try.POSIX
-
+      
       # Import metadata from LI8100 (.81x)
       meta <- read.delim(inputfile, header = F) %>% select(c(1:2)) %>%
         filter(V1 == "Obs#:" | V1 == "Label:" | V1 == "Area:" | V1 == "Vcham:" |
                  V1 == "Offset:" | V1 == "Dead Band:")
-
+      
       if (nrow(meta)/6 == ceiling(nrow(meta)/6)) {
         metadata <- meta %>% reframe(
           Obs = as.numeric(.[which(.[,1] == "Obs#:"),2]),
@@ -197,7 +198,8 @@ import.LI8100 <- function(inputfile, date.format = "ymd", timezone = "UTC",
           Area = as.numeric(.[which(.[,1] == "Area:"),2]),
           Vcham = as.numeric(.[which(.[,1] == "Vcham:"),2]),
           offset = as.numeric(.[which(.[,1] == "Offset:"),2]),
-          deadband = as.numeric(ms(meta[which(meta[,1] == "Dead Band:"),2]), units = "secs"))
+          deadband = as.numeric(ms(meta[which(meta[,1] == "Dead Band:"),2]),
+                                units = "secs"))
       } else {
         metadata <- meta %>% reframe(
           Obs = as.numeric(.[which(.[,1] == "Obs#:"),2]),
@@ -205,48 +207,123 @@ import.LI8100 <- function(inputfile, date.format = "ymd", timezone = "UTC",
           Area = as.numeric(.[which(.[,1] == "Area:"),2]),
           Vcham = as.numeric(.[which(.[,1] == "Vcham:"),2]),
           offset = as.numeric(.[which(.[,1] == "Offset:"),2]),
-          deadband = c(as.numeric(ms(meta[which(meta[,1] == "Dead Band:"),2]), units = "secs"),
-                       last(as.numeric(ms(meta[which(meta[,1] == "Dead Band:"),2]), units = "secs"))))
+          deadband = c(
+            as.numeric(ms(meta[which(meta[,1] == "Dead Band:"),2]),
+                       units = "secs"),
+            last(as.numeric(ms(meta[which(meta[,1] == "Dead Band:"),2]),
+                            units = "secs")))
+        )
       }
-
+      
       # Modify Obs in metadata, if duplicated Obs# (but different Label)
       metadata <- mutate(metadata, Obs2 = row_number())
-
+      
       # Add metadata to data.raw
       data.raw <- data.raw %>%
-        left_join(metadata, by = "Obs2") %>% group_by(Obs2) %>%
-        # Calculate cham.close, cham.open, flag and correct negative values of Etime
-        mutate(cham.close = POSIX.time[which(Etime == 0)],
-               cham.open = max(na.omit(POSIX.time)),
-               obs.start = min(na.omit(POSIX.time))) %>%
+        left_join(metadata, by = "Obs2") %>%
+        group_by(Obs2) %>%
+        
+        # Calculate cham.close and cham.open
+        mutate(
+          cham.close = POSIX.time[which(Etime == 0)[1]],
+          cham.open = max(na.omit(POSIX.time)),
+          obs.start = min(na.omit(POSIX.time))
+        ) %>%
+        
         ungroup() %>%
-        mutate(DATE = substr(POSIX.time, 0, 10),
-               chamID = paste(plotID, Obs, sep = "_"),
-               start.time = cham.close + deadband,
-               Etime = as.numeric(POSIX.time - start.time, units = "secs"),
-               flag = if_else(between(POSIX.time, start.time, cham.open), 1, 0))
-
+        
+        mutate(
+          DATE = substr(POSIX.time, 0, 10),
+          chamID = paste(plotID, Obs, sep = "_"),
+          start.time = cham.close + deadband,
+          # Flag the deadband and flux-fitting period
+          flag = if_else(
+            between(POSIX.time, start.time, cham.open),
+            1,
+            0
+          )
+        ) %>%
+        
+        group_by(Obs2) %>%
+        
+        mutate(
+          # Save the original instrument Etime before replacing it.
+          # For the raw LI-8100 files, Etime is -1 before chamber
+          # closure and then increases during the measurement.
+          Etime.original = Etime,
+          
+          # Find the first row belonging to the flux-fitting period.
+          first.flag = which(flag == 1)[1],
+          
+          # Recalculate Etime.
+          #
+          # For flag == 1:
+          # Use the original LI-8100 Etime and shift it so that the
+          # first flagged row becomes Etime == 0. This preserves the
+          # instrument's Etime progression and therefore avoids
+          # duplicate Etime values caused by duplicate timestamps.
+          #
+          # For flag == 0:
+          # Generate negative Etime values from the row sequence.
+          # This avoids duplicate negative Etime values when timestamps
+          # are duplicated. The last row before the flux-fitting period
+          # receives Etime == -1.
+          Etime = if (any(flag == 1, na.rm = TRUE)) {
+            
+            first.flag <- which(flag == 1)[1]
+            
+            n.before <- first.flag - 1
+            
+            Etime.new <- numeric(n())
+            
+            # Negative Etime values before the flux-fitting period
+            if (n.before > 0) {
+              Etime.new[1:n.before] <- -n.before:-1
+            }
+            
+            # Etime values during the flux-fitting period
+            if (first.flag <= n()) {
+              Etime.new[first.flag:n()] <-
+                Etime.original[first.flag:n()] -
+                Etime.original[first.flag]
+            }
+            
+            Etime.new
+            
+          } else {
+            
+            # If no rows are flagged, retain the sequential negative
+            # Etime values for the whole observation.
+            -seq_len(n())
+          }
+        ) %>%
+        
+        ungroup() %>%
+        
+        # Remove temporary columns
+        select(-Etime.original, -first.flag)
+      
       # Add instrument precision for each gas
       data.raw <- data.raw %>%
         mutate(CO2_prec = prec[1], H2O_prec = prec[2])
-
+      
       # Save cleaned data file
       if(save == TRUE){
         # Create RData folder in working directory
         RData_folder <- paste(getwd(), "RData", sep = "/")
         if(dir.exists(RData_folder) == FALSE){dir.create(RData_folder)}
-
+        
         # Create output file: change extension to .RData, and
         # add instrument name and "imp" for import to file name
         file.name <- gsub(".*/", "", sub("\\.81x", "", inputfile))
         outputfile <- paste("LI8100_", file.name, "_imp.RData", sep = "")
-
+        
         save(data.raw, file = paste(RData_folder, outputfile, sep = "/"))
-
+        
         message(inputfile.name, " saved as ", outputfile,
                 " in RData folder, in working directory\n", sep = "")
       }
-
+      
       if(save == FALSE){
         return(data.raw)
       }


### PR DESCRIPTION
Revised import.LI8100.R to avoid missing or duplicate Etimes in case of missing or duplicate time stamps in the raw data.